### PR TITLE
Build jar using Docker and create Nexus 3 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ CMD ["bin/nexus", "stop"]
 # Copy and Configure Nexus Rundeck Plugin
 RUN mkdir -p system/com/nongfenqi/nexus/plugin/${RUNDECK_PLUGIN_VERSION}
 
-ADD nexus3-rundeck-plugin-${RUNDECK_PLUGIN_VERSION}.jar \
+ADD build/libs/nexus3-rundeck-plugin-${RUNDECK_PLUGIN_VERSION}.jar \
     system/com/nongfenqi/nexus/plugin/${RUNDECK_PLUGIN_VERSION}/nexus3-rundeck-plugin-${RUNDECK_PLUGIN_VERSION}.jar
 
 RUN echo "bundle.mvn\:com.nongfenqi.nexus.plugin/nexus3-rundeck-plugin/"${RUNDECK_PLUGIN_VERSION}" = mvn:com.nongfenqi.nexus.plugin/nexus3-rundeck-plugin/"${RUNDECK_PLUGIN_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM sonatype/nexus3
+
+#Nexus 3 version to use
+ARG NEXUS_VERSION=3.5.1-02
+ARG RUNDECK_PLUGIN_VERSION=1.0.0-SNAPSHOT
+
+USER root
+
+# Stop Nexus 3
+CMD ["bin/nexus", "stop"]
+
+# Copy and Configure Nexus Rundeck Plugin
+RUN mkdir -p system/com/nongfenqi/nexus/plugin/${RUNDECK_PLUGIN_VERSION}
+
+ADD nexus3-rundeck-plugin-${RUNDECK_PLUGIN_VERSION}.jar \
+    system/com/nongfenqi/nexus/plugin/${RUNDECK_PLUGIN_VERSION}/nexus3-rundeck-plugin-${RUNDECK_PLUGIN_VERSION}.jar
+
+RUN echo "bundle.mvn\:com.nongfenqi.nexus.plugin/nexus3-rundeck-plugin/"${RUNDECK_PLUGIN_VERSION}" = mvn:com.nongfenqi.nexus.plugin/nexus3-rundeck-plugin/"${RUNDECK_PLUGIN_VERSION} \
+    >> etc/karaf/profile.cfg \
+    && echo "reference\:file\:com/nongfenqi/nexus/plugin/"${RUNDECK_PLUGIN_VERSION}"/nexus3-rundeck-plugin-"${RUNDECK_PLUGIN_VERSION}".jar = 200" \
+    >> etc/karaf/startup.properties
+
+USER nexus
+
+# Start Nexus 3
+CMD ["bin/nexus", "run"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ Note that if you want to retrieve the artifact from your Rundeck script, you can
 
 The following script allows you to run a Docker with Nexus 3 with nexus3-rundeck-plugin installed.
 
+-  chmod 700 run_docker.sh
 - ./run_docker.sh
+
+Nexus 3 will be running on http://localhost:8081/
 
 The script build the plugin using a Docker image, as is explained in [Using a Docker](using-a-docker) section.
 Using the compiled jar will build the Dockerfile and run a container with Nexus 3 with nexus3-rundeck-plugin installed.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Usage
 
 If you installed and the bundle is activeed, like this.
- 
+
 ![](./doc/image/bundle-activeed.jpeg)
 
 Now you can add url options from the nexus3 to rundeck.
@@ -36,8 +36,8 @@ The plugin provides the following new HTTP resources :
   - `p` : packaging of the artifacts to match ('jar', 'war', etc)
   - `c` : classifier of the artifacts to match ('sources', 'javadoc', etc)
   - `l` : limit - max number of results to return (default 10)
-  
-- `http://NEXUS_HOST/service/siesta/rundeck/maven/options/content` : return artifact stream 
+
+- `http://NEXUS_HOST/service/siesta/rundeck/maven/options/content` : return artifact stream
   Parameters (all required) :
   - `r` : repository ID to search in (null for searching in all indexed repositories)
   - `g` : groupId of the artifacts to match
@@ -47,20 +47,34 @@ The plugin provides the following new HTTP resources :
 Note that if you want to retrieve the artifact from your Rundeck script, you can use content api, example is:
 
     wget "http://NEXUS_HOST/service/siesta/rundeck/maven/options/content?r=reponame&g=${option.groupId}&a=${option.artifactId}&v=${option.version}" --content-disposition
-  
+
 ### Docker repository
+
+The following script allows you to run a Docker with Nexus 3 with nexus3-rundeck-plugin installed.
+
+- ./run_docker.sh
+
+The script build the plugin using a Docker image, as is explained in [Using a Docker](using-a-docker) section.
+Using the compiled jar will build the Dockerfile and run a container with Nexus 3 with nexus3-rundeck-plugin installed.
 
 Welcome to contribute
 
 ### Npm repository
-  
+
 Welcome to contribute
 
 
 ## How to build
 
+### Standard build
+
 - Java 1.8
 - run "./gradlew jar"
 
+### Using a Docker
 
+You can build the plugin easily using a Docker image. With this method is not needed to install a local Gradle environment.
 
+- docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD" -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew "./gradlew jar"
+
+This command run a build inside a Docker image (springyboing/docker-gradlew), with gradlew environment ready.

--- a/README.md
+++ b/README.md
@@ -50,16 +50,6 @@ Note that if you want to retrieve the artifact from your Rundeck script, you can
 
 ### Docker repository
 
-The following script allows you to run a Docker with Nexus 3 with nexus3-rundeck-plugin installed.
-
--  chmod 700 run_docker.sh
-- ./run_docker.sh
-
-Nexus 3 will be running on http://localhost:8081/
-
-The script build the plugin using a Docker image, as is explained in [Using a Docker](using-a-docker) section.
-Using the compiled jar will build the Dockerfile and run a container with Nexus 3 with nexus3-rundeck-plugin installed.
-
 Welcome to contribute
 
 ### Npm repository
@@ -81,3 +71,15 @@ You can build the plugin easily using a Docker image. With this method is not ne
 - docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD":/tmp/nexus3-rundeck-plugin -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew ./gradlew jar
 
 This command run a build inside a Docker image (springyboing/docker-gradlew), with gradlew environment ready.
+
+## Run in Docker
+
+The following script allows you to run a Docker with Nexus 3 with nexus3-rundeck-plugin installed.
+
+-  chmod 700 run_docker.sh
+- ./run_docker.sh
+
+Nexus 3 will be running on http://localhost:8081/
+
+The script build the plugin using a Docker image, as is explained in [Using a Docker](using-a-docker) section.
+Using the compiled jar will build the Dockerfile and run a container with Nexus 3 with nexus3-rundeck-plugin installed.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Welcome to contribute
 
 You can build the plugin easily using a Docker image. With this method is not needed to install a local Gradle environment.
 
-- docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD" -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew "./gradlew jar"
+- docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD":/tmp/nexus3-rundeck-plugin -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew ./gradlew jar
 
 This command run a build inside a Docker image (springyboing/docker-gradlew), with gradlew environment ready.

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ The following script allows you to run a Docker with Nexus 3 with nexus3-rundeck
 
 Nexus 3 will be running on http://localhost:8081/
 
-The script build the plugin using a Docker image, as is explained in [Using a Docker](using-a-docker) section.
+The script build the plugin using a Docker image, as is explained in [Using a Docker](#using-a-docker) section.
 Using the compiled jar will build the Dockerfile and run a container with Nexus 3 with nexus3-rundeck-plugin installed.

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,8 @@
+# This command run a Docker image (springyboing/docker-gradlew), with gradlew environment ready, to build the plugin
+docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD" -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew "./gradlew jar"
+
+# Build Nexus 3 + nexus3-rundeck-plugin docker
+docker build --rm=true --tag=nexus3-rundeck-plugin/nexus3 .
+
+# Start Nexus 3 with Rundeck Plugin
+docker run -d -p 8081:8081 --name nexus nexus3-rundeck-plugin/nexus3

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,5 +1,5 @@
 # This command run a Docker image (springyboing/docker-gradlew), with gradlew environment ready, to build the plugin
-docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD" -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew "./gradlew jar"
+docker run -it --rm --name nexus3-rundeck-plugin -v "$PWD":/tmp/nexus3-rundeck-plugin -w /tmp/nexus3-rundeck-plugin springyboing/docker-gradlew ./gradlew jar
 
 # Build Nexus 3 + nexus3-rundeck-plugin docker
 docker build --rm=true --tag=nexus3-rundeck-plugin/nexus3 .


### PR DESCRIPTION
I propose this change as a first step, to Dockerize the project.

Next steps will be, add continuous integration to provide jar and publish Docker container in public Docker repository.

Added method to build plugin using Docker without need to install Gradle environment locally.

Added Dockerfile and script to build a Docker image with nexus3-rundeck-plugin installed in Nexus 3.

