### PR TITLE
Compatibility with nexus 3.38 - null pointer exception when the class…

### DIFF
--- a/src/main/java/com/nongfenqi/nexus/plugin/rundeck/RundeckMavenResource.java
+++ b/src/main/java/com/nongfenqi/nexus/plugin/rundeck/RundeckMavenResource.java
@@ -161,9 +161,10 @@ public class RundeckMavenResource
         if (!isBlank(artifactId)) {
             searchRequestBuilder.searchFilter("attributes.maven2.artifactId", artifactId);
         }
-        if (!isBlank(classifier)) {
-            searchRequestBuilder.searchFilter("assets.attributes.maven2.classifier", classifier);
-        }
+
+        classifier = !isBlank(classifier) ? classifier : "";
+        searchRequestBuilder.searchFilter("assets.attributes.maven2.classifier", classifier);
+
         if (!isBlank(extension)) {
             searchRequestBuilder.searchFilter("assets.attributes.maven2.extension", extension);
         }


### PR DESCRIPTION
…ifier is not set

* nexus 3.38 requires the classifier to be set (at least empty) otherwise it is throwing a null pointer exception